### PR TITLE
fix build error: TX2, RX2 -> TX2_pin, RX2_pin

### DIFF
--- a/src/dma_serial.h
+++ b/src/dma_serial.h
@@ -4,8 +4,8 @@
 // but it uses ESP32 DMA to send and receive data
 // much faster
 
-const int RX2 = 16;
-const int TX2 = 17;
+const int RX2_pin = 16;
+const int TX2_pin = 17;
 // we work at 1 ms, so 32 samples per ms at 31250 bauds
 // 1024 must be more than enough
 const int UART_BUFFER_SIZE = 1024;
@@ -28,7 +28,8 @@ class DmaSerial {
     ESP_ERROR_CHECK(
         uart_driver_install(UART_NUM_2, UART_BUFFER_SIZE * 2, UART_BUFFER_SIZE * 2, 0, NULL, 0));
     ESP_ERROR_CHECK(uart_param_config(UART_NUM_2, &uart_config));
-    ESP_ERROR_CHECK(uart_set_pin(UART_NUM_2, TX2, RX2, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
+    ESP_ERROR_CHECK(
+        uart_set_pin(UART_NUM_2, TX2_pin, RX2_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
   }
 
   template<typename T>

--- a/src/hardware_config.h
+++ b/src/hardware_config.h
@@ -89,10 +89,10 @@ void setupHardware() {
   encoder.setCount(0);
   encoder.setFilter(1023);
 
-//   pinMode(DIP_0, INPUT_PULLUP);
-//   pinMode(DIP_1, INPUT_PULLUP);
-//   pinMode(DIP_2, INPUT_PULLUP);
-//   pinMode(DIP_3, INPUT_PULLUP);
+  //   pinMode(DIP_0, INPUT_PULLUP);
+  //   pinMode(DIP_1, INPUT_PULLUP);
+  //   pinMode(DIP_2, INPUT_PULLUP);
+  //   pinMode(DIP_3, INPUT_PULLUP);
   pinMode(BUTTON_A, INPUT_PULLUP);
   pinMode(BUTTON_B, INPUT_PULLUP);
   pinMode(ENCODER_SW, INPUT_PULLUP);
@@ -108,7 +108,6 @@ void setupHardware() {
 
   pinMode(OUT_2, OUTPUT);
   pinMode(OUT_3, OUTPUT);
-
 
   // randomSeed(analogRead(0));
 
@@ -139,7 +138,7 @@ void setupHardware() {
   // test Serial2 for loopback
 
   /*
-  Serial2.begin(31250, SERIAL_8N1, RX2, TX2);
+  Serial2.begin(31250, SERIAL_8N1, RX2_pin, TX2_pin);
   Serial.println("Serial2 for MIDI loopback test initialized.");
   delay(1000);
   // Send some bytes


### PR DESCRIPTION
```
CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32dev.html
PLATFORM: Espressif 32 (6.10.0) > Espressif ESP32 Dev Module
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES: 
 - framework-arduinoespressif32 @ 3.20017.241212+sha.dcc1105b 
 - tool-esptoolpy @ 1.40501.0 (4.5.1) 
 - toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch5
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 40 compatible libraries
Scanning dependencies...
Dependency Graph
|-- Adafruit GFX Library @ 1.11.11
|-- Adafruit SSD1306 @ 2.5.13
|-- ESP32Encoder @ 0.10.2
|-- MIDI Library @ 5.0.2
|-- Bounce2 @ 2.72.0
|-- ArduinoJson @ 7.3.0
|-- SPI @ 2.0.0
|-- Wire @ 2.0.0
|-- WebServer @ 2.0.0
Building in release mode
Compiling .pio/build/esp32dev/src/main.cpp.o
Compiling .pio/build/esp32dev/src/tests/dsp_pybind11.cpp.o
Archiving .pio/build/esp32dev/lib650/libAdafruit GFX Library.a
Indexing .pio/build/esp32dev/lib650/libAdafruit GFX Library.a
In file included from /home/mike/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:196,
                 from .pio/libdeps/esp32dev/Adafruit GFX Library/Adafruit_GFX.h:5,
                 from .pio/libdeps/esp32dev/Adafruit GFX Library/Fonts/Picopixel.h:2,
                 from src/main.cpp:1:
/home/mike/.platformio/packages/framework-arduinoespressif32/cores/esp32/HardwareSerial.h:169:31: error: expected initializer before numeric constant
       #define RX2 (gpio_num_t)16
                               ^~
src/dma_serial.h:7:11: note: in expansion of macro 'RX2'
 const int RX2 = 16;
           ^~~
/home/mike/.platformio/packages/framework-arduinoespressif32/cores/esp32/HardwareSerial.h:177:31: error: expected initializer before numeric constant
       #define TX2 (gpio_num_t)17
                               ^~
src/dma_serial.h:8:11: note: in expansion of macro 'TX2'
 const int TX2 = 17;
           ^~~
Archiving .pio/build/esp32dev/lib82d/libAdafruit SSD1306.a
Indexing .pio/build/esp32dev/lib82d/libAdafruit SSD1306.a
Archiving .pio/build/esp32dev/lib7fe/libESP32Encoder.a
Indexing .pio/build/esp32dev/lib7fe/libESP32Encoder.a
Archiving .pio/build/esp32dev/libc4c/libBounce2.a
Indexing .pio/build/esp32dev/libc4c/libBounce2.a
Archiving .pio/build/esp32dev/lib074/libWiFi.a
Indexing .pio/build/esp32dev/lib074/libWiFi.a
*** [.pio/build/esp32dev/src/main.cpp.o] Error 1
Compiling .pio/build/esp32dev/lib188/FS/FS.cpp.o
```